### PR TITLE
change(log): use logging instead of print to allow upper packages manage the messaging level

### DIFF
--- a/pyad/__init__.py
+++ b/pyad/__init__.py
@@ -1,3 +1,7 @@
+# package logger
+import logging
+logging.basicConfig(level=logging.WARNING)
+
 __all__ = [
     "set_defaults",
     "ADQuery",

--- a/pyad/adbase.py
+++ b/pyad/adbase.py
@@ -1,17 +1,20 @@
+import logging
 import sys
 import win32com.client
 
 from .pyadexceptions import SetupError
 
+logger = logging.getLogger(__name__)
 _adsi_provider = win32com.client.Dispatch("ADsNameSpaces")
 
 try:
     # Discover default domain and forest information
     __default_domain_obj = _adsi_provider.GetObject("", "LDAP://rootDSE")
 except:
-    # If there was an error, this this computer might not be on a domain.
-    print(
-        "WARN: unable to connect to default domain. Computer is likely not attached to an AD domain"
+    # If there was an error, this computer might not be on a domain.
+    logger.info(
+        "Unable to connect to default domain. "
+        "Computer is likely not attached to an AD domain."
     )
     __default_domain_obj = None
     _default_detected_forest = None

--- a/pyad/adobject.py
+++ b/pyad/adobject.py
@@ -1,3 +1,4 @@
+import logging
 import win32com
 import pywintypes
 import time
@@ -16,6 +17,7 @@ from .pyadconstants import (
     ADS_USER_FLAG,
 )
 
+logger = logging.getLogger(__name__)
 
 @total_ordering
 class ADObject(ADBase):
@@ -664,7 +666,7 @@ class ADObject(ADBase):
                             )
                         node.appendChild(text)
                     except:
-                        print("attribute: %s not xml-able" % attribute)
+                        logger.error("attribute: %s not xml-able" % attribute)
                 else:
                     node.setAttribute("type", "multiValued")
                     ok_elem = False
@@ -684,7 +686,7 @@ class ADObject(ADBase):
                                 node.appendChild(valnode)
                                 ok_elem = True
                     except:
-                        print("attribute: %s not xml-able" % attribute)
+                        logger.error("attribute: %s not xml-able" % attribute)
                 if ok_elem:
                     adobj_xml_doc.appendChild(node)
         return doc.toxml(encoding="UTF-8")


### PR DESCRIPTION
Basically, this PR replace `print` by logging module.

The actual behavior always print messages without any control on it by upper packages:

```powershell
Python 3.10.8 (tags/v3.10.8:aaaf517, Oct 11 2022, 16:50:30) [MSC v.1933 64 bit (AMD64)] on win32
Type "help", "copyright", "credits" or "license" for more information.
>>> import pyad
Unable to connect to default domain. Computer is likely not attached to an AD domain.
>>>
```

With this PR, the actual message is managed with logging module and decreased to info level (since it's not blocking or a real issue):

```powershell
Python 3.10.8 (tags/v3.10.8:aaaf517, Oct 11 2022, 16:50:30) [MSC v.1933 64 bit (AMD64)] on win32
Type "help", "copyright", "credits" or "license" for more information.
>>> import pyad
>>>
```

It allows to control the display level through classic logging configuration:

```powershell
Python 3.10.8 (tags/v3.10.8:aaaf517, Oct 11 2022, 16:50:30) [MSC v.1933 64 bit (AMD64)] on win32
Type "help", "copyright", "credits" or "license" for more information.
>>> import logging    
>>> logging.basicConfig(level=logging.INFO)    
>>> import pyad       
INFO:pyad.adbase:Unable to connect to default domain. Computer is likely not attached to an AD domain.
>>>
```