### PR TITLE
fix(packaging): make published and setup.py versions consistent (0.6.2)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ def read(fname):
 
 setup(
     name="python-win-ad",
-    version="0.6.1",
+    version="0.6.2",
     author="Zakir Durumeric",
     author_email="zakird@gmail.com",
     maintainer="Josh Carswell",


### PR DESCRIPTION
The published and latest tag is the 0.6.2 (https://github.com/jcarswell/pyad/releases/tag/0.6.2). This PR fixes the value in setup.py.