### PR TITLE
fix(logs): logging.basicConfig is breaking log chain

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+0.6.4 / 2024-10-02 / Guts
+
+	PR: fix(logs): run logging.basicConfig only in main mode
+
 0.6.3 / 2024-10-02 / Guts
 
 	PR: change(log): use logging instead of print to allow upper packages manage the messaging level

--- a/pyad/__init__.py
+++ b/pyad/__init__.py
@@ -1,6 +1,3 @@
-# package logger
-import logging
-logging.basicConfig(level=logging.WARNING)
 
 __all__ = [
     "set_defaults",
@@ -69,3 +66,8 @@ from .pyadexceptions import (
     noExecutedQuery,
     invalidResults,
 )
+
+
+if __name__ == "__main__":
+    import logging
+    logging.basicConfig(level=logging.WARNING)

--- a/pyad/adbase.py
+++ b/pyad/adbase.py
@@ -12,7 +12,7 @@ try:
     __default_domain_obj = _adsi_provider.GetObject("", "LDAP://rootDSE")
 except:
     # If there was an error, this computer might not be on a domain.
-    logger.info(
+    logger.debug(
         "Unable to connect to default domain. "
         "Computer is likely not attached to an AD domain."
     )


### PR DESCRIPTION
hi @jcarswell 

Sorry, I'm fixing what I introduced myself in https://github.com/jcarswell/pyad/pull/5.

Importing pyad in a package (https://github.com/qgis-deployment/qgis-deployment-toolbelt-cli/blob/7c49fb112a82326c85c9e7cf1d73f59e2bbcb835/qgis_deployment_toolbelt/utils/user_groups.py) was leading to a systemic log message:

```python
WARN: unable to connect to default domain. Computer is likely not attached to an AD domain.
```


